### PR TITLE
[BD-19] adds es integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
 
 script:
   - make test-docker
+  - make test_integration_with_es
   - make quality-docker
   - make coverage-docker
 

--- a/Makefile
+++ b/Makefile
@@ -156,3 +156,15 @@ generate-spark-egg-files:
 	cd /var/tmp/ && mkdir -p /var/tmp/edx-ccx-keys/  && tar --strip-components=1 -xzf /var/tmp/edx-ccx-keys.tar.gz -C /var/tmp/edx-ccx-keys/
 	cd /var/tmp/edx-ccx-keys && python setup.py bdist_egg
 	cp /var/tmp/edx-ccx-keys/dist/edx_ccx_keys-0.2.1-py2.7.egg  /var/tmp/edx_egg_files/edx_ccx_keys.egg
+
+test.start_elasticsearch:
+	docker-compose up -d
+	sleep 20
+
+test.stop_elasticsearch:
+	docker-compose stop
+
+test.elasticsearch_integration:
+	python -m nose edx/analytics/tasks/tests/elasticsearch_integration
+
+test_integration_with_es: test.start_elasticsearch test.elasticsearch_integration test.stop_elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '2.2'
+services:
+
+  test_elasticsearch_integration:
+    image: elasticsearch:7.8.0
+    container_name: test_elasticsearch_integration
+    environment:
+      - node.name=test_elasticsearch_integration
+      - cluster.name=docker-cluster
+      - cluster.initial_master_nodes=test_elasticsearch_integration
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - http.port=9200
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - edx_analytics_pipeline_data:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+
+volumes:
+  edx_analytics_pipeline_data:
+    driver: local

--- a/edx/analytics/tasks/tests/elasticsearch_integration/test_elasticsearch_service.py
+++ b/edx/analytics/tasks/tests/elasticsearch_integration/test_elasticsearch_service.py
@@ -1,0 +1,31 @@
+"""
+Tests integration with ES 7.8.0 version
+"""
+from unittest import TestCase
+import edx.analytics.tasks.tests.acceptance.services.elasticsearch_service as es_service
+
+
+class TestElasticsearchService(TestCase):
+    """
+    Tests integration with ES for acceptance tests by ElasticsearchService interface.
+    """
+
+    def setUp(self):
+        self.config = {"elasticsearch_host": "localhost"}
+        self.index = "test_index"
+        self.alias = "test_alias"
+        self.es_service = es_service.ElasticsearchService(self.config, self.alias)
+        self.es_client = self.es_service.client
+        self.es_client.indices.create(index=self.index)
+        self.es_client.indices.update_aliases({"actions": [{"add": {"index": self.index, "alias": self.alias}}]})
+
+    def tearDown(self):
+        self.es_client.indices.delete(index=self.index, ignore=[400, 404])
+
+    def test_reset(self):
+        """
+        Tests reset method of the ElasticsearchService class.
+        """
+        self.assertTrue(self.es_client.indices.exists_alias(name=self.alias, index=self.index))
+        self.es_service.reset()
+        self.assertFalse(self.es_client.indices.exists(index=self.index))


### PR DESCRIPTION
**Description:** elasticsearch client lib fails, when we try to get index by alias, during acceptance testing with error:
```
  File "/usr/local/lib/python2.7.12/lib/python2.7/unittest/case.py", line 320, in run
    self.setUp()
  File "/var/lib/jenkins/jobs/STU-acceptance-es-upgrade/workspace/analytics-tasks/edx/analytics/tasks/tests/acceptance/__init__.py", line 304, in setUp
    self.reset_external_state()
  File "/var/lib/jenkins/jobs/STU-acceptance-es-upgrade/workspace/analytics-tasks/edx/analytics/tasks/tests/acceptance/__init__.py", line 329, in reset_external_state
    self.elasticsearch.reset()
  File "/var/lib/jenkins/jobs/STU-acceptance-es-upgrade/workspace/analytics-tasks/edx/analytics/tasks/tests/acceptance/services/elasticsearch_service.py", line 40, in reset
    response = self._elasticsearch_client.indices.get_alias(name=self._alias)
  File "/var/lib/jenkins/jobs/STU-acceptance-es-upgrade/workspace/build/venvs/analytics-tasks/lib/python2.7/site-packages/elasticsearch/client/utils.py", line 139, in _wrapped
    return func(*args, params=params, headers=headers, **kwargs)
  File "/var/lib/jenkins/jobs/STU-acceptance-es-upgrade/workspace/build/venvs/analytics-tasks/lib/python2.7/site-packages/elasticsearch/client/indices.py", line 499, in get_alias
    "GET", _make_path(index, "_alias", name), params=params, headers=headers
  File "/var/lib/jenkins/jobs/STU-acceptance-es-upgrade/workspace/build/venvs/analytics-tasks/lib/python2.7/site-packages/elasticsearch/transport.py", line 352, in perform_request
    timeout=timeout,
'perform_request() got an unexpected keyword argument \'headers\'
```
  
**Youtrack:** [ticket](https://youtrack.raccoongang.com/issue/OeX_ES-49), [review ticket](https://youtrack.raccoongang.com/issue/OeX_ES-52)

Reviewed by:
- [ ] @NikolayBorovenskiy
