### PR TITLE
Pin pip version less than 21.0

### DIFF
--- a/share/task.yml
+++ b/share/task.yml
@@ -150,7 +150,7 @@
 
     - name: update pip
       command: >
-        {{ working_venv_dir }}/bin/pip install -U pip
+        {{ working_venv_dir }}/bin/pip install -U "pip < 21.0"
 
     - name: virtualenv initialized on Debian
       shell: >


### PR DESCRIPTION
**Pin pip version less than 21.0 because this version drop support for Python 2.**

**Pip 21.0 (2021-01-23)**
**Deprecations and Removals**
- Drop support for Python 2. (#6148)
- Remove support for legacy wheel cache entries that were created with pip versions older than 20.0. (#7502)
- Remove support for VCS pseudo URLs editable requirements. It was emitting deprecation warning since version 20.0.
- Modernise the codebase after Python 2. (#8802)
- Drop support for Python 3.5. (#9189)
- Remove the VCS export feature that was used only with editable VCS requirements and had correctness issues. (#9338)


Analytics Pipeline Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
