### PR TITLE
Added several attempts to repeat the task

### DIFF
--- a/share/task.yml
+++ b/share/task.yml
@@ -148,9 +148,13 @@
         virtualenv --python={{ virtualenv_python }} {{ virtualenv_extra_args }} {{ working_venv_dir }}
       when: not virtualenv_created.stat.exists
 
-    - name: update pip
+   - name: update pip
       command: >
-        {{ working_venv_dir }}/bin/pip install -U "pip < 21.0"
+        {{ working_venv_dir }}/bin/pip install --index-url=https://pypi.org/simple/ -U "pip < 21.0"
+      retries: 10
+      delay: 5
+      register: result
+      until: result.rc == 0
 
     - name: virtualenv initialized on Debian
       shell: >


### PR DESCRIPTION
Added several attempts to repeat the task before the task is failed, needed for fix error in task update pip

failed: [10.10.0.38] => {"changed": true, "cmd": ["/var/lib/analytics-tasks/automation/venv/bin/pip", "install", "--index-url=https://pypi.org/simple/", "-U", "pip==20.3.4"], "delta": "0:00:00.251493", "end": "2021-04-05 19:10:58.756622", "rc": 1, "start": "2021-04-05 19:10:58.505129"}
stdout: Downloading/unpacking pip==20.3.4
  Cannot fetch index base URL https://pypi.org/simple/
  Could not find any downloads that satisfy the requirement pip==20.3.4
Cleaning up...
No distributions at all found for pip==20.3.4
Storing complete log in /home/hadoop/.pip/pip.log

Analytics Pipeline Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] If you have a migration please contact data engineering team before merging.
  - [ ] Before merging run full acceptance tests suite and provide URL for the acceptance tests run.
  - [ ] A member of data engineering team has approved the pull request.
  
